### PR TITLE
Enlarge _POSIX_PIPE_BUFF

### DIFF
--- a/addr2line.go
+++ b/addr2line.go
@@ -79,7 +79,7 @@ func (a *Addr2line) ResolveString(addr string) ([]Result, error) {
 	if _, err := fmt.Fprintf(a.w, "%s\n", addr); err != nil {
 		return nil, err
 	}
-	const _POSIX_PIPE_BUF = 512
+	const _POSIX_PIPE_BUF = 1024
 	buf := make([]byte, _POSIX_PIPE_BUF)
 	// binutil addr2line fflush after writing to pipe. Hopefully would be able to read it atomically
 	n, err := a.r.Read(buf)


### PR DESCRIPTION
the buffer size is too small.
Here an example where the current size is too small:
```
$ addr2line -i -f -e vmlinux.debug ffffffff810b9bd0
arch_atomic64_try_cmpxchg
/home/alessandro/src/linux-5.18.4/./arch/x86/include/asm/atomic64_64.h:190
arch_atomic_long_try_cmpxchg_acquire
/home/alessandro/src/linux-5.18.4/./include/linux/atomic/atomic-long.h:443
atomic_long_try_cmpxchg_acquire
/home/alessandro/src/linux-5.18.4/./include/linux/atomic/atomic-instrumented.h:1781
rwsem_write_trylock
/home/alessandro/src/linux-5.18.4/kernel/locking/rwsem.c:254
__down_write_trylock
/home/alessandro/src/linux-5.18.4/kernel/locking/rwsem.c:1279
down_write_trylock
/home/alessandro/src/linux-5.18.4/kernel/locking/rwsem.c:1542
```